### PR TITLE
Indent yaml files

### DIFF
--- a/config/mirror.yaml
+++ b/config/mirror.yaml
@@ -1,6 +1,8 @@
-min_longitudinal_offset: 1.8
-max_longitudinal_offset: 3.2
-min_lateral_offset: -1.4
-max_lateral_offset: 1.4
-min_height_offset: 0.8
-max_height_offset: 1.5
+/**:
+  ros__parameters:
+    min_longitudinal_offset: 1.8
+    max_longitudinal_offset: 3.2
+    min_lateral_offset: -1.4
+    max_lateral_offset: 1.4
+    min_height_offset: 0.8
+    max_height_offset: 1.5

--- a/config/simulator_model.yaml
+++ b/config/simulator_model.yaml
@@ -1,29 +1,31 @@
-acc_time_constant: 0.1
-acc_time_delay: 0.1
-accel_rate: 7.0
-add_measurement_noise: true
-angvel_lim: 3.0
-angvel_noise_stddev: 0.0
-angvel_rate: 1.0
-angvel_time_constant: 0.5
-angvel_time_delay: 0.2
-initial_engage_state: true
-pos_noise_stddev: 0.01
-rpy_noise_stddev: 0.0001
-sim_steering_gear_ratio: 15.0
-steer_lim: 1.0
-steer_noise_stddev: 0.0001
-steer_rate_lim: 5.0
-steer_time_constant: 0.27
-steer_time_delay: 0.24
-tread_length: 1.0
+/**:
+  ros__parameters:
+    acc_time_constant: 0.1
+    acc_time_delay: 0.1
+    accel_rate: 7.0
+    add_measurement_noise: true
+    angvel_lim: 3.0
+    angvel_noise_stddev: 0.0
+    angvel_rate: 1.0
+    angvel_time_constant: 0.5
+    angvel_time_delay: 0.2
+    initial_engage_state: true
+    pos_noise_stddev: 0.01
+    rpy_noise_stddev: 0.0001
+    sim_steering_gear_ratio: 15.0
+    steer_lim: 1.0
+    steer_noise_stddev: 0.0001
+    steer_rate_lim: 5.0
+    steer_time_constant: 0.27
+    steer_time_delay: 0.24
+    tread_length: 1.0
 
-# Option for vehicle_model_type:
-# - IDEAL_STEER : reads velocity command. The steering and velocity changes exactly the same as commanded.
-# - DELAY_STEER : reads velocity command. The steering and velocity changes with delay model.
-# - DELAY_STEER_ACC : reads acceleration command. The steering and acceleration changes with delay model.
-vehicle_model_type: DELAY_STEER_ACC
-vel_lim: 50.0
-vel_noise_stddev: 0.0
-vel_time_constant: 0.61
-vel_time_delay: 0.25
+    # Option for vehicle_model_type:
+    # - IDEAL_STEER : reads velocity command. The steering and velocity changes exactly the same as commanded.
+    # - DELAY_STEER : reads velocity command. The steering and velocity changes with delay model.
+    # - DELAY_STEER_ACC : reads acceleration command. The steering and acceleration changes with delay model.
+    vehicle_model_type: DELAY_STEER_ACC
+    vel_lim: 50.0
+    vel_noise_stddev: 0.0
+    vel_time_constant: 0.61
+    vel_time_delay: 0.25

--- a/config/vehicle_info.yaml
+++ b/config/vehicle_info.yaml
@@ -1,9 +1,11 @@
-wheel_radius: 0.39
-wheel_width: 0.42
-wheel_base: 2.74 # between front wheel center and rear wheel center
-wheel_tread: 1.63 # between left wheel center and right wheel center
-front_overhang: 1.0 # between front wheel center and vehicle front
-rear_overhang: 1.03 # between rear wheel center and vehicle rear 
-left_overhang: 0.1 # between left wheel center and vehicle left
-right_overhang: 0.1 # between right wheel center and vehicle right
-vehicle_height: 2.5
+/**:
+  ros__parameters:
+    wheel_radius: 0.39
+    wheel_width: 0.42
+    wheel_base: 2.74 # between front wheel center and rear wheel center
+    wheel_tread: 1.63 # between left wheel center and right wheel center
+    front_overhang: 1.0 # between front wheel center and vehicle front
+    rear_overhang: 1.03 # between rear wheel center and vehicle rear
+    left_overhang: 0.1 # between left wheel center and vehicle left
+    right_overhang: 0.1 # between right wheel center and vehicle right
+    vehicle_height: 2.5


### PR DESCRIPTION
In the initial port, it seems the param files of `lexus_description` were not used. They need to be indented in ROS2 to avoid a segfault.

In `npc_simulator`, I now rely on these values so this should be merged fast. Anyone with the appropriate rights, please go ahead

@esteve @TakaHoribe @mitsudome-r 

fyi @nnmm 