### PR TITLE
Add ros__parameters namespace on vehicle_info.yaml

### DIFF
--- a/config/vehicle_info.yaml
+++ b/config/vehicle_info.yaml
@@ -1,9 +1,11 @@
-wheel_radius: 0.39
-wheel_width: 0.42
-wheel_base: 2.74 # between front wheel center and rear wheel center
-wheel_tread: 1.63 # between left wheel center and right wheel center
-front_overhang: 1.0 # between front wheel center and vehicle front
-rear_overhang: 1.03 # between rear wheel center and vehicle rear
-left_overhang: 0.1 # between left wheel center and vehicle left
-right_overhang: 0.1 # between right wheel center and vehicle right
-vehicle_height: 2.5
+/**:
+  ros__parameters:
+    wheel_radius: 0.39
+    wheel_width: 0.42
+    wheel_base: 2.74 # between front wheel center and rear wheel center
+    wheel_tread: 1.63 # between left wheel center and right wheel center
+    front_overhang: 1.0 # between front wheel center and vehicle front
+    rear_overhang: 1.03 # between rear wheel center and vehicle rear
+    left_overhang: 0.1 # between left wheel center and vehicle left
+    right_overhang: 0.1 # between right wheel center and vehicle right
+    vehicle_height: 2.5

--- a/urdf/vehicle.xacro
+++ b/urdf/vehicle.xacro
@@ -7,7 +7,7 @@
   <!-- vehicle body -->
   <link name="base_link">
     <visual>
-      <origin xyz="${vehicle_info['wheel_base']/2.0} 0 0" rpy="${pi/2.0} 0 ${pi}"/>
+      <origin xyz="${vehicle_info['/**']['ros__parameters']['wheel_base']/2.0} 0 0" rpy="${pi/2.0} 0 ${pi}"/>
       <geometry>
         <mesh filename="package://lexus_description/mesh/lexus.dae" scale="1 1 1"/>
       </geometry>


### PR DESCRIPTION
Add ros__parameters namespace on vehicle_info.yaml to be loaded as a ros parameter.

The xacro command is modified regarding this change.

# how to test

Launch the vehicle_launch to check if the vehicle_info.yaml is correctly loaded to generate the vehicle_description.
```
ros2 launch vehicle_launch vehicle_description.launch.xml sensor_model:=aip_xx1 vehicle_model:=lexus vehicle_id:=default
```