### PR TITLE
fix param file name in xacro file

### DIFF
--- a/urdf/vehicle.xacro
+++ b/urdf/vehicle.xacro
@@ -2,7 +2,7 @@
 <robot xmlns:xacro="http://ros.org/wiki/xacro">
 
   <!-- load parameter -->
-  <xacro:property name="vehicle_info" value="${load_yaml('$(find lexus_description)/config/vehicle_info.yaml')}"/>
+  <xacro:property name="vehicle_info" value="${load_yaml('$(find lexus_description)/config/vehicle_info.param.yaml')}"/>
 
   <!-- vehicle body -->
   <link name="base_link">


### PR DESCRIPTION
Param file name was changed in this commit https://github.com/tier4/lexus_description.iv.universe/commit/1e28427e51e51385fcac90a35dcfb8030a394366, but xacro referring to the file was not fixed. 

Signed-off-by: mitsudome-r <ryohsuke.mitsudome@tier4.jp>